### PR TITLE
PR: Integración con Mailer API (auth por magic link, contacto y cotizador)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=Link-del-backend-aqui
+VITE_RECAPTCHA_SITE_KEY=clave-del-recaptcha-aqui

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ dist/
 *.log
 
 # Entornos
+.example
 .env
-.env.*
 !.env.example
 
 # Hostinger storage y config (nunca versionar)

--- a/public/pricing.json
+++ b/public/pricing.json
@@ -1,0 +1,15 @@
+{
+  "currency": "CLP",
+  "format": "es-CL",
+
+  "ready": { "A": 1500000, "B": 1400000, "C": 1200000, "D": 1000000 },
+  "beer": { "A": 1300000, "B": 1200000, "C": 1100000, "D": 900000 },
+  "coldbrew": { "A": 900000, "B": 800000, "C": 700000, "D": 600000 },
+
+  "overrides": {
+    "ready::Gin Tonic::Lata 350ml::menos de 500L": 1600000,
+    "ready::Gin Tonic::Lata 350ml::Entre 500 - 2.000 L": 1500000,
+    "ready::Gin Tonic::Lata 350ml::Entre 2.000 - 10.000 L": 1350000,
+    "ready::Gin Tonic::Lata 350ml::Sobre 10.000 L": 1200000
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,8 @@ import Proposal from "./pages/Proposal.jsx";
 import Contacto from "./pages/Contacto.jsx";
 import CotizadorWizard from "./pages/CotizadorWizard.jsx";
 import Login from "./pages/Login.jsx";
+import AuthCallback from "./pages/AuthCallback.jsx";
+
 
 export default function App() {
   return (
@@ -31,6 +33,7 @@ export default function App() {
         <Route path="/terminos" element={<Terminos />} />
         <Route path="/privacidad" element={<Privacidad />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
       </Routes>
 
       <Footer />

--- a/src/components/Financiamiento.jsx
+++ b/src/components/Financiamiento.jsx
@@ -1,51 +1,256 @@
-import { Row, Col, Card } from "react-bootstrap";
+import { useEffect, useMemo, useState } from "react";
+import { Row, Col, Card, Button, Alert, Spinner } from "react-bootstrap";
+import { api } from "../services/api";
+
+const PRICE_URL = "/public_html/pricing.json";
+
+function formatCLP(n) {
+  return new Intl.NumberFormat("es-CL", {
+    style: "currency",
+    currency: "CLP",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
 
 export default function Financiamiento({ branch, answers }) {
+  const [pricing, setPricing] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [msg, setMsg] = useState({ type: "", text: "" });
+
+  const qty = Number(
+    answers?.cantidad ??
+      answers?.["Cantidad a producir"] ??
+      answers?.["Cantidad a producir "] ??
+      0
+  );
+
+  // Cargar pricing.json
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const r = await fetch(PRICE_URL);
+        const data = await r.json();
+        if (mounted) {
+          setPricing(data);
+          setLoading(false);
+        }
+      } catch {
+        if (mounted) {
+          setPricing(null);
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // Precio base según branch/cantidad + overrides
+  const basePrice = useMemo(() => {
+    if (!pricing || !branch || !qty) return 0;
+
+    const table = pricing[branch];
+    if (!table) return 0;
+
+    // buckets A/B/C/D por cantidad
+    let bucket = "A";
+    if (qty >= 2000 && qty < 10000) bucket = "C";
+    else if (qty >= 500 && qty < 2000) bucket = "B";
+    else if (qty >= 10000) bucket = "D";
+
+    // Overrides (ej: ready → Gin Tonic 350ml por tramos)
+    if (
+      branch === "ready" &&
+      answers?.sabor === "Gin Tonic" &&
+      /350/.test(String(answers?.formato || ""))
+    ) {
+      const o = pricing.overrides ?? {};
+      if (qty < 500 && o["ready::Gin Tonic::Lata 350ml::menos de 500L"]) {
+        return o["ready::Gin Tonic::Lata 350ml::menos de 500L"];
+      }
+      if (
+        qty >= 500 &&
+        qty < 2000 &&
+        o["ready::Gin Tonic::Lata 350ml::Entre 500 - 2.000 L"]
+      ) {
+        return o["ready::Gin Tonic::Lata 350ml::Entre 500 - 2.000 L"];
+      }
+      if (
+        qty >= 2000 &&
+        qty < 10000 &&
+        o["ready::Gin Tonic::Lata 350ml::Entre 2.000 - 10.000 L"]
+      ) {
+        return o["ready::Gin Tonic::Lata 350ml::Entre 2.000 - 10.000 L"];
+      }
+      if (qty >= 10000 && o["ready::Gin Tonic::Lata 350ml::Sobre 10.000 L"]) {
+        return o["ready::Gin Tonic::Lata 350ml::Sobre 10.000 L"];
+      }
+    }
+
+    return table[bucket] || 0;
+  }, [pricing, branch, answers, qty]);
+
+  const totals = useMemo(() => {
+    const base = basePrice || 0;
+    const transferencia = Math.round(base * 0.95); // 5% dcto
+    const tarjeta = Math.round(base * 1.12); // 12 cuotas (referencia)
+    return { base, transferencia, tarjeta };
+  }, [basePrice]);
+
+  async function handleQuote(plan) {
+    try {
+      setMsg({ type: "", text: "" });
+
+      // 1) email desde la sesión (cookie httpOnly)
+      const status = await api.status();
+      const email = status?.user?.email || "";
+      if (!email)
+        throw new Error("No pudimos obtener tu sesión. Inicia sesión de nuevo.");
+
+      // 2) descripción del item
+      const branchLabel =
+        branch === "beer"
+          ? "Cerveza"
+          : branch === "ready"
+          ? "Cócteles"
+          : branch === "coldbrew"
+          ? "Cold Brew Coffee"
+          : "Producto";
+
+      const detailParts = [];
+      if (answers?.estilo) detailParts.push(answers.estilo);
+      if (answers?.sabor) detailParts.push(answers.sabor);
+      if (answers?.formato) detailParts.push(answers.formato);
+      if (answers?.mlproducto) detailParts.push(String(answers.mlproducto));
+
+      const description = `Producción ${branchLabel}${
+        detailParts.length ? " — " + detailParts.join(" · ") : ""
+      }`;
+
+      // 3) total según plan
+      const total =
+        plan === "transfer"
+          ? totals.transferencia
+          : plan === "credit"
+          ? totals.tarjeta
+          : totals.base;
+
+      // 4) payload “simple” (1 ítem)
+      const payload = {
+        name: email,
+        email,
+        currency: "CLP",
+        items: [{ description, quantity: 1, unitPrice: total }],
+        notes: `Plan: ${plan}. Cantidad: ${qty}.`,
+      };
+
+      await api.quote(payload);
+      setMsg({
+        type: "success",
+        text: "¡Cotización enviada! Te contactaremos pronto.",
+      });
+    } catch (e) {
+      setMsg({
+        type: "danger",
+        text: e.message || "No pudimos enviar la cotización.",
+      });
+    }
+  }
+
+  if (loading) {
+    return (
+      <section className="text-center">
+        <Spinner animation="border" size="sm" /> Cargando precios…
+      </section>
+    );
+  }
+
   return (
-    <section>
-      <h2 className="h4 mb-3 text-center">Elige tu financiamiento</h2>
-      <p className="text-muted text-center">
-        El valor de la propuesta podría estar sujeta a cambios una vez realizada
-        la reunión técnica.
-      </p>
+    <>
+      {/* Estilo embebido para los botones (paleta CanLAB) */}
+      <style>{`
+        .btn-canlab {
+          background-color: #e0b13c !important; /* dorado */
+          border-color: #e0b13c !important;
+          color: #0b2f46 !important;           /* azul */
+          font-weight: 600;
+          line-height: 1.2;
+        }
+        .btn-canlab:hover,
+        .btn-canlab:focus,
+        .btn-canlab:active {
+          background-color: #d1a233 !important; /* dorado un poco más oscuro */
+          border-color: #d1a233 !important;
+          color: #0b2f46 !important;
+          box-shadow: none !important;
+        }
+      `}</style>
 
-      <Row className="justify-content-center">
-        <Col xs={12} md={8} lg={6} xl={5} className="mx-auto">
-          {/* Transferencia */}
-          <Card className="mb-3 shadow-sm">
-            <Card.Body>
-              <Row className="align-items-center">
-                <Col>
-                  <Card.Title className="h5 mb-1">Transferencia</Card.Title>
-                  <p className="mb-0">5% de descuento</p>
-                </Col>
-                <Col xs="auto" className="text-end">
-                  <div className="fw-semibold">VALORX</div>
-                </Col>
-              </Row>
-            </Card.Body>
-          </Card>
+      <section>
+        <h2 className="h4 mb-3 text-center">Elige tu financiamiento</h2>
+        <p className="text-muted text-center">
+          El valor de la propuesta podría estar sujeta a cambios una vez realizada la
+          reunión técnica.
+        </p>
 
-          {/* Tarjeta de crédito */}
-          <Card className="mb-3 shadow-sm">
-            <Card.Body>
-              <Row className="align-items-center">
-                <Col>
-                  <Card.Title className="h5 mb-1">
-                    Tarjeta de crédito
-                  </Card.Title>
-                  <p className="mb-0">
-                    Paga en 12 cuotas con todo medio de pago
-                  </p>
-                </Col>
-                <Col xs="auto" className="text-end">
-                  <div className="fw-semibold">VALORX</div>
-                </Col>
-              </Row>
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
-    </section>
+        {msg.text && (
+          <div className="d-flex justify-content-center">
+            <Alert className="w-100" style={{ maxWidth: 760 }} variant={msg.type}>
+              {msg.text}
+            </Alert>
+          </div>
+        )}
+
+        <Row className="justify-content-center">
+          <Col xs={12} md={8} lg={6} xl={5} className="mx-auto">
+            {/* Transferencia */}
+            <Card className="mb-3 shadow-sm">
+              <Card.Body>
+                <Row className="align-items-center g-3">
+                  <Col>
+                    <Card.Title className="h5 mb-1">Transferencia</Card.Title>
+                    <p className="mb-1">5% de descuento</p>
+                    <Button size="sm" className="btn-canlab" onClick={() => handleQuote("transfer")}>
+                      Solicitar cotización
+                    </Button>
+                  </Col>
+                  <Col xs="auto" className="text-end">
+                    <div className="fw-semibold">{formatCLP(totals.transferencia)}</div>
+                  </Col>
+                </Row>
+              </Card.Body>
+            </Card>
+
+            {/* Tarjeta de crédito */}
+            <Card className="mb-3 shadow-sm">
+              <Card.Body>
+                <Row className="align-items-center g-3">
+                  <Col>
+                    <Card.Title className="h5 mb-1">Tarjeta de crédito</Card.Title>
+                    <p className="mb-1">Paga en 12 cuotas con todo medio de pago</p>
+                    <Button size="sm" className="btn-canlab" onClick={() => handleQuote("credit")}>
+                      Solicitar cotización
+                    </Button>
+                  </Col>
+                  <Col xs="auto" className="text-end">
+                    <div className="fw-semibold">{formatCLP(totals.tarjeta)}</div>
+                  </Col>
+                </Row>
+              </Card.Body>
+            </Card>
+
+            {/* Subtotal de referencia */}
+            <Card className="mb-3 shadow-sm">
+              <Card.Body className="d-flex justify-content-between">
+                <div className="text-muted">Subtotal de referencia</div>
+                <div className="fw-semibold">{formatCLP(totals.base)}</div>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      </section>
+    </>
   );
 }

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,0 +1,33 @@
+// src/pages/AuthCallback.jsx
+import { useEffect } from "react";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+export default function AuthCallback() {
+  useEffect(() => {
+    // token puede venir como ?token=... o #token=...
+    const qs = new URLSearchParams(window.location.search);
+    let token = qs.get("token");
+
+    if (!token && window.location.hash) {
+      const hs = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+      token = hs.get("token");
+    }
+
+    if (!token || token.length < 20) {
+      window.location.replace("/login");
+      return;
+    }
+
+    // Deja que el backend verifique y haga el redirect (ahí se aplica el Set-Cookie)
+    const url = `${API_URL}/api/auth/verify?token=${encodeURIComponent(token)}`;
+    window.location.replace(url);
+  }, []);
+
+  return (
+    <div style={{ padding: 24, textAlign: "center" }}>
+      <h1>Validando tu sesión…</h1>
+      <p>Te redirigiremos en un momento.</p>
+    </div>
+  );
+}

--- a/src/pages/CotizadorWizard.jsx
+++ b/src/pages/CotizadorWizard.jsx
@@ -1,7 +1,11 @@
+// src/pages/CotizadorWizard.jsx
 import React, { useEffect, useMemo, useState } from "react";
 import { Container, Card, Button, ProgressBar, Alert } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import "./CotizadorWizard.css";
+
+// ⬇️ NUEVO: guardamos el wizard en sessionStorage + localStorage
+import { saveWizard } from "../services/wizardStore";
 
 const BRANCHES = {
   start: [
@@ -35,7 +39,7 @@ const BRANCHES = {
     },
     {
       key: "cantidad",
-      type: "number", // input numérico
+      type: "number",
       question:
         "¿Qué cantidad estimada necesitas para la primera producción? (mínimo 500 L)",
       min: 500,
@@ -63,7 +67,7 @@ const BRANCHES = {
     },
     {
       key: "Cantidad a producir",
-      type: "number", // input numérico
+      type: "number",
       question: "Cantidad de latas que necesitas (mínimo 500)",
       min: 500,
       unit: "unidades",
@@ -78,7 +82,7 @@ const BRANCHES = {
     },
     {
       key: "Cantidad a producir",
-      type: "number", // input numérico
+      type: "number",
       question: "Cantidad de latas que necesitas (enlatado 473cc, mínimo 500)",
       min: 500,
       unit: "unidades",
@@ -159,7 +163,10 @@ export default function CotizadorWizard() {
         branchLabel: CATEGORY_LABELS[branch],
         answers: nextAnswers,
       };
-      sessionStorage.setItem("wizardData", JSON.stringify(payload));
+
+      // ⬇️ CAMBIO CLAVE: persistimos en sessionStorage + localStorage
+      saveWizard(payload);
+
       navigate("/login");
     }
   };
@@ -229,7 +236,8 @@ export default function CotizadorWizard() {
                       key={value}
                       variant="light"
                       className="wizard-option"
-                      onClick={() => selectOption(value)}>
+                      onClick={() => selectOption(value)}
+                    >
                       {label}
                     </Button>
                   );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,16 +1,19 @@
+// src/pages/Login.jsx
 import { useEffect, useState } from "react";
+import { Container, Card, Form, Button, Alert } from "react-bootstrap";
 
-const API_URL = import.meta.env.VITE_API_URL || ""; // ej. http://localhost:3000
+const API_URL = import.meta.env.VITE_API_URL || "";
 const RECAPTCHA_SITE_KEY = (import.meta.env.VITE_RECAPTCHA_SITE_KEY || "").trim();
 const HAS_RECAPTCHA = RECAPTCHA_SITE_KEY.length > 0;
 
 export default function Login() {
-  const [rcReady, setRcReady] = useState(!HAS_RECAPTCHA); // si no hay key, listo de inmediato
+  const [rcReady, setRcReady] = useState(!HAS_RECAPTCHA);
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
+  const [okMsg, setOkMsg] = useState("");
 
-  // Carga del script SOLO si hay site key
+  // Cargar reCAPTCHA sólo si hay key
   useEffect(() => {
     if (!HAS_RECAPTCHA) return;
 
@@ -18,63 +21,85 @@ export default function Login() {
       window.grecaptcha.ready(() => setRcReady(true));
       return;
     }
-
     const s = document.createElement("script");
     s.src = `https://www.google.com/recaptcha/api.js?render=${encodeURIComponent(RECAPTCHA_SITE_KEY)}`;
     s.async = true;
     s.onload = () => window.grecaptcha.ready(() => setRcReady(true));
     s.onerror = () => {
-      // No bloqueamos el flujo en local: dejamos rcReady en true para permitir el submit.
-      setRcReady(true);
+      setRcReady(true); // en dev no bloqueamos
       setError("No se pudo cargar reCAPTCHA (ignorado en desarrollo).");
     };
     document.head.appendChild(s);
   }, []);
 
-  const handleSubmit = async (e) => {
+  async function handleSubmit(e) {
     e.preventDefault();
     setError("");
-
+    setOkMsg("");
     try {
       setLoading(true);
-
-      let recaptchaToken = undefined;
+      let recaptchaToken;
       if (HAS_RECAPTCHA && window.grecaptcha?.execute) {
         await new Promise((res) => window.grecaptcha.ready(res));
         recaptchaToken = await window.grecaptcha.execute(RECAPTCHA_SITE_KEY, { action: "request_link" });
       }
-
       const res = await fetch(`${API_URL}/api/auth/request-link`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, recaptchaToken }), // token opcional
+        body: JSON.stringify({ email, recaptchaToken }),
       });
-
       const data = await res.json().catch(() => ({}));
       if (!res.ok || !data?.ok) throw new Error(data?.error || "No pudimos enviar el enlace.");
-
-      alert("Te enviamos un enlace de verificación a tu correo 🙌");
+      setOkMsg("Te enviamos un enlace de verificación a tu correo 🙌");
     } catch (err) {
       setError(err.message || "Error enviando el enlace.");
     } finally {
       setLoading(false);
     }
-  };
+  }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <input
-        type="email"
-        placeholder="tu@correo.com"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-      />
-      <button type="submit" disabled={loading || (HAS_RECAPTCHA && !rcReady)}>
-        {loading ? "Enviando..." : "Recibir enlace"}
-      </button>
-      {error && <p style={{ color: "crimson" }}>{error}</p>}
-    </form>
+    <Container className="py-5" style={{ maxWidth: 680 }}>
+      <style>{`
+        .login-card { border-radius: 12px; max-width: 600px; }
+        .login-title { font-weight: 700; font-size: 1.5rem; text-align:center; }
+        .login-sub { color:#6c757d; text-align:center; font-size: .95rem; }
+        .login-btn { font-weight: 600; padding:.625rem 1rem; } /* más bajo que el lg */
+      `}</style>
+
+      <Card className="shadow-sm login-card mx-auto">
+        <Card.Body className="p-4">
+          <h3 className="login-title mb-2">Verifica tu correo</h3>
+          <p className="login-sub mb-4">
+            Te enviaremos un enlace para continuar a tu propuesta.
+          </p>
+
+          {okMsg && <Alert variant="success" className="mb-3">{okMsg}</Alert>}
+          {error && <Alert variant="danger" className="mb-3">{error}</Alert>}
+
+          <Form onSubmit={handleSubmit}>
+            <Form.Group className="mb-3" controlId="loginEmail">
+              <Form.Label>Correo</Form.Label>
+              <Form.Control
+                type="email"
+                placeholder="tucorreo@dominio.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </Form.Group>
+
+            <Button
+              type="submit"
+              className="w-100 login-btn"
+              disabled={loading || (HAS_RECAPTCHA && !rcReady)}
+            >
+              {loading ? "Enviando..." : "Enviar enlace"}
+            </Button>
+          </Form>
+        </Card.Body>
+      </Card>
+    </Container>
   );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,29 @@
+/// <reference types="vite/client" />
+const API = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+
+async function http<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    credentials: "include",              // <- importante para cookie
+    headers: { "content-type": "application/json", ...(init.headers || {}) },
+    ...init
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data?.error || "request_failed");
+  return data as T;
+}
+
+export const api = {
+  // contacto
+  contact: (body: { name: string; email: string; message: string; recaptchaToken?: string }) =>
+    http<{ ok: true }>("/api/contact", { method: "POST", body: JSON.stringify(body) }),
+
+  // cotización
+  quote: (body: any) =>
+    http<{ ok: true }>("/api/quote", { method: "POST", body: JSON.stringify(body) }),
+
+  // auth
+  requestLink: (email: string, recaptchaToken?: string) =>
+    http<{ ok: true }>("/api/auth/request-link", { method: "POST", body: JSON.stringify({ email, recaptchaToken }) }),
+  status: () => http<{ authenticated: boolean; user?: any }>("/api/auth/status"),
+  logout: () => http<{ ok: true }>("/api/auth/logout", { method: "POST" })
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,29 +1,112 @@
 /// <reference types="vite/client" />
-const API = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
+
+const BASE = (import.meta.env.VITE_API_URL || "http://localhost:3000").replace(/\/+$/, "");
+
+/** Build + fetch con cookies httpOnly habilitadas */
 async function http<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const res = await fetch(`${API}${path}`, {
-    credentials: "include",              // <- importante para cookie
-    headers: { "content-type": "application/json", ...(init.headers || {}) },
-    ...init
+  const url = `${BASE}${path.startsWith("/") ? "" : "/"}${path}`;
+
+  const res = await fetch(url, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...(init.headers || {}) },
+    ...init,
   });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok) throw new Error(data?.error || "request_failed");
+
+  const isJson = (res.headers.get("content-type") || "").includes("application/json");
+  const data: any = isJson ? await res.json().catch(() => ({})) : {};
+
+  if (!res.ok) throw new Error(data?.error || data?.message || `HTTP ${res.status}`);
   return data as T;
 }
 
+/* ===================== Tipos ===================== */
+
+export interface QuoteItem {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface QuoteBody {
+  name: string;
+  email: string;
+  currency: string; // "CLP", "USD", etc.
+  items: QuoteItem[];
+  notes?: string;
+}
+
+export interface ContactBody {
+  name: string;
+  email: string;
+  phone?: string;       
+  message: string;
+  recaptchaToken?: string; 
+}
+
+export interface AuthUser {
+  email: string;
+  role?: string;
+  iat?: number;
+  exp?: number;
+}
+
+export interface AuthStatus {
+  authenticated: boolean;
+  user?: AuthUser;
+}
+
+/* ===================== API ===================== */
+
 export const api = {
   // contacto
-  contact: (body: { name: string; email: string; message: string; recaptchaToken?: string }) =>
-    http<{ ok: true }>("/api/contact", { method: "POST", body: JSON.stringify(body) }),
+  contact: (body: ContactBody) =>
+    http<{ ok: true }>("/api/contact", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 
   // cotización
-  quote: (body: any) =>
-    http<{ ok: true }>("/api/quote", { method: "POST", body: JSON.stringify(body) }),
+  quote: (body: QuoteBody) =>
+    http<{ ok: true }>("/api/quote", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 
   // auth
   requestLink: (email: string, recaptchaToken?: string) =>
-    http<{ ok: true }>("/api/auth/request-link", { method: "POST", body: JSON.stringify({ email, recaptchaToken }) }),
-  status: () => http<{ authenticated: boolean; user?: any }>("/api/auth/status"),
-  logout: () => http<{ ok: true }>("/api/auth/logout", { method: "POST" })
+    http<{ ok: true; sentTo?: string }>("/api/auth/request-link", {
+      method: "POST",
+      body: JSON.stringify({ email, recaptchaToken }),
+    }),
+
+  status: () => http<AuthStatus>("/api/auth/status"),
+
+  logout: () => http<{ ok: true }>("/api/auth/logout", { method: "POST" }),
+
+
+  auth: {
+    requestLink: (email: string, recaptchaToken?: string) =>
+      http<{ ok: true; sentTo?: string }>("/api/auth/request-link", {
+        method: "POST",
+        body: JSON.stringify({ email, recaptchaToken }),
+      }),
+    status: () => http<AuthStatus>("/api/auth/status"),
+    logout: () => http<{ ok: true }>("/api/auth/logout", { method: "POST" }),
+  },
+
+
+  pricing: async <T = any>() => {
+    const r = await fetch("/public_html/pricing.json");
+    return (await r.json()) as T;
+  },
 };
+
+
+export function getAuthEmailFromStatus(s: AuthStatus | null | undefined) {
+  return s?.authenticated ? s.user?.email ?? "" : "";
+}
+
+/* ===== Aliases legacy para compatibilidad (si algún componente antiguo los usa) ===== */
+export const getAuthStatus = api.status;
+export const postQuote = (body: QuoteBody) => api.quote(body);

--- a/src/services/wizardStore.ts
+++ b/src/services/wizardStore.ts
@@ -1,0 +1,32 @@
+// src/services/wizardStore.ts
+export type WizardData = {
+  branch: string;
+  branchLabel: string;
+  answers: Record<string, unknown>;
+};
+
+const KEY = "wizardData";
+
+export function saveWizard(data: WizardData) {
+  const s = JSON.stringify(data);
+  sessionStorage.setItem(KEY, s);
+  localStorage.setItem(KEY, s);
+}
+
+export function loadWizard(): WizardData | null {
+  const a = sessionStorage.getItem(KEY);
+  if (a) { try { return JSON.parse(a); } catch {} }
+  const b = localStorage.getItem(KEY);
+  if (b) {
+    try {
+      sessionStorage.setItem(KEY, b); // repoblar para esta pestaña
+      return JSON.parse(b);
+    } catch {}
+  }
+  return null;
+}
+
+export function clearWizard() {
+  sessionStorage.removeItem(KEY);
+  localStorage.removeItem(KEY);
+}


### PR DESCRIPTION


> **Objetivo:** conectar el frontend con la nueva API en Vercel, habilitar login por *magic link* (cookie httpOnly), y dejar funcionando formularios de **Contacto** y **Cotizador** con manejo de CORS/credenciales.

---

##  Contexto
La API (`/api/*`) ya está desplegada en Vercel con CORS configurado por origen y cookies httpOnly. Este PR adapta el frontend para consumirla correctamente (en local y en producción), manteniendo el flujo existente de UI y agregando la pantalla de **Login** con *magic link*.

---

## Cambios incluidos

1. **Cliente HTTP centralizado**
   - Nuevo wrapper `api.ts` que expone:
     - `api.contact(body)` → `POST /api/contact`
     - `api.quote(body)`   → `POST /api/quote`
     - `api.auth.requestLink(email, recaptchaToken?)` → `POST /api/auth/request-link`
     - `api.auth.status()` y `api.auth.logout()`
   - Todas las peticiones usan `credentials: "include"` para permitir cookies httpOnly.

2. **Pantalla de Login (magic link)**
   - Vista `Login.jsx` con formulario de email.
   - Soporte **opcional** de reCAPTCHA v3 (si hay key configurada).
   - Mensajería de éxito/errores amigable para el usuario.

3. **Formularios operativos**
   - **Contacto:** integra `api.contact` y muestra confirmación.
   - **Cotizador:** integra `api.quote` y muestra éxito; mantiene UI y copy actuales.

4. **Variables de entorno (Vite)**
   - Soporte para `VITE_API_URL` y `VITE_RECAPTCHA_SITE_KEY`.
   - El cliente detecta entorno:
     - **Local:** `VITE_API_URL=http://localhost:3000`
     - **Prod:** `VITE_API_URL=https://<dominio-de-la-api>`

5. **Manejo robusto de CORS/cookies**
   - Todas las llamadas que requieren sesión envían credenciales.
   - Documentado el requisito de **SameSite=None; Secure** en prod (cookie httpOnly la setea el backend).

---

##  Configuración requerida

### 1) Frontend (`.env` de Vite)
Ejemplo para **desarrollo**:
```env
VITE_API_URL=http://localhost:3000
# Opcional (si se usa reCAPTCHA v3)
# VITE_RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

Ejemplo para **producción** (Vercel u otro hosting):
```env
VITE_API_URL=https://mailer-sigma-six.vercel.app
# VITE_RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

### 2) Backend (referencia — ya aplicado)
- `CORS_ORIGIN` incluye el origen del front (p.ej. `http://localhost:5173` en dev, dominio del front en prod).
- Auth por magic link emite cookie httpOnly; en prod usa `SameSite=None; Secure`.

---

## QA / Cómo probar

**Login (magic link)**
1. Ir a `/login` en el front.
2. Ingresar correo válido y enviar.
3. Ver mensaje de éxito (“Te enviamos un enlace…”).
4. Confirmar que llega el correo desde la API de Resend.
5. (Opcional) Abrir `…/auth/callback?token=…` y validar que tras `/api/auth/verify` redirige al front con cookie de sesión.

**Contacto**
1. Completar formulario de contacto.
2. Debe responder `200 { ok: true }` y mostrar confirmación.

**Cotizador**
1. Enviar cotización desde la UI.
2. Debe responder `200 { ok: true }` y mostrar confirmación.

**Network/CORS**
- Ver en devtools que las requests a `/api/*` llevan **Credentials: include**.
- En preflight se permiten métodos `GET, POST, OPTIONS` y `Content-Type: application/json`.

---

## Notas y consideraciones

- En **desarrollo** el backend puede redirigir el magic link a `FRONT_URL=http://localhost:5173`.
- Si se habilita reCAPTCHA v3, el front envía `recaptchaToken`, de lo contrario el backend puede ignorarlo en dev.
- **Errores comunes** (resueltos):
  - `CORS error` → asegurarse de que `CORS_ORIGIN` (API) y `VITE_API_URL` (Front) apunten a los valores correctos.
  - `net::ERR_FAILED` en `request-link` → faltaba `credentials: "include"` o mismatch de orígenes.

---

##  Checklist del revisor

- [ ] `VITE_API_URL` apunta al despliegue correcto (dev/prod).
- [ ] (Si aplica) `VITE_RECAPTCHA_SITE_KEY` configurado y visible en Network como `?render=…`.
- [ ] Requests a `/api/*` muestran **cookie** en la respuesta (Set-Cookie httpOnly) y **Credentials: include** en la request.
- [ ] Formularios de **Contacto** y **Cotizador** devuelven `ok: true` y muestran confirmación.
- [ ] UI/UX sin regresiones visuales en rutas tocadas.

---

## Plan de despliegue / rollback
- **Despliegue:** publicar front con `.env` correctos + verificar `/login`, `/contacto` y flujo de cotización.
- **Rollback:** revertir a la etiqueta anterior del front. La API es retrocompatible con los endpoints usados aquí.

